### PR TITLE
Updates to notification screen

### DIFF
--- a/HealthyGatorSportsFanRN/app/(tabs)/notifications.tsx
+++ b/HealthyGatorSportsFanRN/app/(tabs)/notifications.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import React, { useState, useEffect, useRef } from 'react';
-import { StyleSheet, View, Text, TouchableOpacity, TextInput, Button, Platform, FlatList, ScrollView, Alert} from 'react-native';
+import { StyleSheet, View, Text, TouchableOpacity, TextInput, Button, Platform, FlatList, ScrollView, Alert, KeyboardAvoidingView, SafeAreaView} from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
@@ -140,7 +140,9 @@ const NotificationsPage = () => {
 
         <View style={styles.container}>
 
-            <Text style={styles.title}>Notifications</Text>
+        <Text style={styles.title}>Notifications</Text>
+
+        <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding" keyboardVerticalOffset={Platform.select({ ios: 90, android: 120 })}>
 
             <View style={styles.shadowContainer}>
                 <ScrollView>
@@ -174,7 +176,7 @@ const NotificationsPage = () => {
                 </View>
             </View>
 
-            <Text style={{ fontSize: 15 }}>Create a notification for testing:</Text>
+            <Text style={{ fontSize: 15, marginTop: 10, marginBottom: 10, alignSelf: 'center'}}>Create a notification for testing:</Text>
 
             <View style={styles.buttonContainer}>
                 <TextInput
@@ -199,7 +201,9 @@ const NotificationsPage = () => {
                 <Text style={styles.buttonText}>Generate notification</Text>
             </TouchableOpacity>
 
+            </KeyboardAvoidingView>
         </View>  
+
     );
 }
 
@@ -374,8 +378,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
     },
     shadowContainer: {
-        width: '90%', // Adjust as needed
-        height: '50%', // Adjust as needed        
+        height: '60%', // Adjust as needed        
         borderRadius: 10,
         backgroundColor: 'white',
         shadowColor: '#000',
@@ -394,8 +397,8 @@ const styles = StyleSheet.create({
     },
     buttonContainer: {
         flexDirection: 'row',
-        justifyContent: 'space-between', // Adjusts spacing between buttons
-        width: '90%', // Adjust as needed
+        justifyContent: 'space-between',
+        marginBottom: 10,
     },
     buttonForContainer: {
         flex: 1, // Makes buttons take equal space
@@ -418,14 +421,14 @@ const styles = StyleSheet.create({
     },
     button: {
         backgroundColor: '#2196F3', // Default button color
-        paddingVertical: 5,
-        paddingHorizontal: 10,
+        padding: 10,
         borderRadius: 4,
         elevation: 2, // For Android shadow
         shadowColor: '#000', // For iOS shadow
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.3,
         shadowRadius: 4,
+        alignSelf: 'center'
       },
       buttonText: {
         color: 'white',

--- a/HealthyGatorSportsFanRN/app/(tabs)/notifications.tsx
+++ b/HealthyGatorSportsFanRN/app/(tabs)/notifications.tsx
@@ -142,7 +142,7 @@ const NotificationsPage = () => {
 
         <Text style={styles.title}>Notifications</Text>
 
-        <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding" keyboardVerticalOffset={Platform.select({ ios: 90, android: 120 })}>
+        <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding" keyboardVerticalOffset={Platform.select({ ios: 60, android: 80 })}>
 
             <View style={styles.shadowContainer}>
                 <ScrollView>
@@ -176,9 +176,7 @@ const NotificationsPage = () => {
                 </View>
             </View>
 
-            <Text style={{ fontSize: 15, marginTop: 10, marginBottom: 10, alignSelf: 'center'}}>Create a notification for testing:</Text>
-
-            <View style={styles.buttonContainer}>
+            <View style={[styles.buttonContainer, {marginBottom: 5}]}>
                 <TextInput
                     style={styles.editBox}
                     placeholder="Title"
@@ -196,10 +194,31 @@ const NotificationsPage = () => {
                     onChangeText={newMessage => setNewMessage(newMessage)}
                 />
             </View>
+
+            <View style={styles.buttonContainer}>
+                <Text style={[{ fontSize: 15, width: '60%'}]}>Test creating & sending a notification from the frontend:</Text>
+
+                <TouchableOpacity style={[styles.buttonForContainer, {backgroundColor: '#FFD580', marginHorizontal: 0}]} onPress={handleCreateNotificationPress}>
+                    <Text style={[styles.buttonForContainerText, {color: 'black', fontSize: 15}]}>Generate notification</Text>
+                </TouchableOpacity>
+
+            </View>
             
-            <TouchableOpacity style={styles.button} onPress={handleCreateNotificationPress}>
-                <Text style={styles.buttonText}>Generate notification</Text>
-            </TouchableOpacity>
+            <View style={styles.separator}>
+                <View style={styles.content}>
+                    <Text>--------------------------------------------------------------------------------------</Text>
+                </View>
+            </View>
+
+            <View style={[styles.buttonContainer, {marginTop: 10}]}>
+
+                <Text style={[{ fontSize: 15, width: '60%'}]}>Test sending a notification from backend based on CFBD API:</Text>
+
+                <TouchableOpacity style={[styles.buttonForContainer, {backgroundColor: '#FFD580', marginHorizontal: 5}]} onPress={handlePollCFBD}>
+                    <Text style={[styles.buttonForContainerText, {color: 'black', fontSize: 15}]}>Get next game info</Text>
+                </TouchableOpacity>
+
+            </View>
 
             </KeyboardAvoidingView>
         </View>  
@@ -378,7 +397,7 @@ const styles = StyleSheet.create({
         alignItems: 'center',
     },
     shadowContainer: {
-        height: '60%', // Adjust as needed        
+        height: '50%', // Adjust as needed        
         borderRadius: 10,
         backgroundColor: 'white',
         shadowColor: '#000',
@@ -428,7 +447,7 @@ const styles = StyleSheet.create({
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.3,
         shadowRadius: 4,
-        alignSelf: 'center'
+        alignSelf: 'center',
       },
       buttonText: {
         color: 'white',
@@ -440,6 +459,9 @@ const styles = StyleSheet.create({
         borderWidth: 1,
         marginRight: '5%',
         margin: 5,
+        borderRadius: 5,
+        padding: 10,
+        borderColor: '#D3D3D3',
     },
     card: {
         marginBottom: 5,
@@ -475,7 +497,7 @@ const styles = StyleSheet.create({
     separator: {
         height: 1, // Height of the line
         backgroundColor: '#CCCCCC', // Color of the line
-        marginVertical: 10, // Space around the line
+        marginVertical: 5, // Space around the line
       },
       content: {
         marginTop: 70, // Adjust to avoid overlap with the title

--- a/HealthyGatorSportsFanRN/app/(tabs)/notifications.tsx
+++ b/HealthyGatorSportsFanRN/app/(tabs)/notifications.tsx
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
         fontSize: 24,
         fontWeight: 'bold',
         marginBottom: 10,
-        marginTop: 10,
+        marginTop: '10%',
         textAlign: 'center',
     },
     buttonContainer: {


### PR DESCRIPTION
Added KeyboardAvoidingView so you can see when you're typing on notification page instead of the keyboard covering the input boxes. This video shows a before & after of keyboard behavior (changes are applied at ~second 17):
https://drive.google.com/file/d/1B_eRJ7Yi5z83Ymkpcew76wenoJpt7mPW/view?usp=drive_link

**Update to PR:**
I added back in the "Get next game info button so I can test Expo's notification service through a development build. Also adjusted look & feel, and made the test-buttons orange to differentiate. Will call this out in the demo.
New look:
![image](https://github.com/user-attachments/assets/b058cfc5-f5df-419d-8e98-c52bafe99c09)