### PR TITLE
Added AppUrls.ts constants file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ __pycache__/
 HealthyGatorSportsFanDjango/celerybeat-schedule.bak
 HealthyGatorSportsFanDjango/celerybeat-schedule.dat
 HealthyGatorSportsFanDjango/celerybeat-schedule.dir
+
+# Ignore AppUrls.ts file so Host URL changes can be made locally without disrupting default Heroku URL for app in production
+HealthyGatorSportsFanRN\constants\AppUrls.ts


### PR DESCRIPTION
This way host URL changes can be made locally without disrupting default Heroku URL for app in production